### PR TITLE
[feat] 튜터 수업 가능 시간 등록/삭제 API 구현 (#1)

### DIFF
--- a/app/controllers/api/v1/availabilities_controller.rb
+++ b/app/controllers/api/v1/availabilities_controller.rb
@@ -1,0 +1,15 @@
+# app/controllers/api/v1/availabilities_controller.rb
+class Api::V1::AvailabilitiesController < ApplicationController
+    def create
+      tutor = Tutor.find(params[:tutor_id])
+      availability = tutor.availabilities.create!(start_time: params[:start_time])
+      render json: availability, status: :created
+    end
+  
+    def destroy
+      availability = Availability.find(params[:id])
+      availability.destroy
+      head :no_content
+    end
+  end
+  

--- a/app/controllers/api/v1/slots_controller.rb
+++ b/app/controllers/api/v1/slots_controller.rb
@@ -1,0 +1,41 @@
+# app/controllers/api/v1/slots_controller.rb
+class Api::V1::SlotsController < ApplicationController
+    def index
+      start_date = Date.parse(params[:start_date])
+      end_date = Date.parse(params[:end_date])
+      duration = params[:duration].to_i
+  
+      start_times = []
+      (start_date..end_date).each do |date|
+        (0..47).each do |i|  # 30분 단위로 하루 48개
+          time = date.to_time + i * 30.minutes
+          if duration == 30
+            start_times << time if Availability.exists?(start_time: time)
+          elsif duration == 60
+            next_time = time + 30.minutes
+            if Availability.exists?(start_time: time) && Availability.exists?(start_time: next_time)
+              start_times << time
+            end
+          end
+        end
+      end
+  
+      render json: start_times.uniq.map { |t| { start_time: t } }
+    end
+  
+    def available_tutors
+      start_time = Time.parse(params[:start_time])
+      duration = params[:duration].to_i
+  
+      tutors = Tutor.joins(:availabilities)
+      tutors = tutors.where(availabilities: { start_time: start_time })
+  
+      if duration == 60
+        second_block = start_time + 30.minutes
+        tutors = tutors.where(id: Tutor.joins(:availabilities).where(availabilities: { start_time: second_block }).pluck(:id))
+      end
+  
+      render json: tutors.select(:id, :name)
+    end
+  end
+  

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,15 @@
 class ApplicationController < ActionController::API
-end
+    rescue_from ActiveRecord::RecordNotFound, with: :not_found
+    rescue_from ActiveRecord::RecordInvalid, with: :unprocessable_entity
+  
+    private
+  
+    def not_found(error)
+      render json: { error: error.message }, status: :not_found
+    end
+  
+    def unprocessable_entity(error)
+      render json: { error: error.record.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+  


### PR DESCRIPTION
### 📌 작업 개요
튜터가 자신의 수업 가능 시간을 등록하거나 삭제할 수 있는 API를 구현했습니다.

---

### 🔧 주요 작업 내용
- POST `/tutors/:tutor_id/availabilities`  
  → `start_time`으로 가능 시간 등록

- DELETE `/availabilities/:id`  
  → 등록된 시간 삭제 기능 추가

- 컨트롤러: `AvailabilitiesController` 생성 및 액션 정의
- 예외 처리: 유효하지 않은 튜터/시간 요청 시 404 또는 422 응답 반환

---

### ✅ 테스트
- Postman으로 등록/삭제 요청 테스트 완료
- 유효성 검증 및 에러 응답 확인 완료

---

### 🔗 관련 이슈
Closes #1 
